### PR TITLE
Add Dockerfile and Makefile for gemini-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-slim
+
+# Install git for working with repositories
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+# Install gemini-cli globally
+RUN npm install -g @google/gemini-cli
+
+# Set workdir
+WORKDIR /workspace
+
+ENTRYPOINT ["gemini"]
+CMD []

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+IMAGE_NAME ?= gemini-cli
+
+.PHONY: build run
+
+build:
+    docker build -t $(IMAGE_NAME) .
+
+run:
+    docker run -it --rm \
+        -v $(PWD):/workspace \
+        -v $(HOME)/.gitconfig:/root/.gitconfig:ro \
+        -e GEMINI_API_KEY \
+        -e GOOGLE_API_KEY \
+        -e GOOGLE_CLOUD_PROJECT \
+        -e GOOGLE_CLOUD_LOCATION \
+        -e GOOGLE_GENAI_USE_VERTEXAI \
+        $(IMAGE_NAME) $(ARGS)


### PR DESCRIPTION
## Summary
- add Dockerfile for running gemini-cli with Node 20 and git
- add Makefile to build the image and run gemini-cli with token-based auth

## Testing
- `docker build -t gemini-cli .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877721a2438832db7effc2ecafc8390